### PR TITLE
Compound Interest implemented

### DIFF
--- a/src/powerups/compound_interest.cr
+++ b/src/powerups/compound_interest.cr
@@ -1,0 +1,84 @@
+require "../powerup.cr"
+
+class PowerupCompoundInterest < Powerup
+  BASE_PRICE = 10000.0
+  KEY = "compound_interest_stack"
+  LAST_BONUS_KEY = "compound_interest_bonus"
+
+  def self.get_powerup_id
+    "compound_interest"
+  end
+
+  def get_name
+    "Compounding Interest"
+  end
+
+  def get_description (public_key)
+    "Your units/s increases by 1% for every 10,000 units you currently have. One time purchase.\n
+    Current bonus: #{(get_bonus(public_key)).round(2)}x"
+  end
+
+  def is_stackable
+    false
+  end
+
+  def get_price(public_key)
+    BASE_PRICE
+  end
+
+  def is_available_for_purchase(private_key)
+    !is_purchased(private_key)
+  end
+
+  def is_purchased(public_key)
+    @game.get_key_value(public_key, KEY) == "true"
+  end
+
+  def get_last_bonus(public_key)
+    last_bonus = @game.get_key_value(public_key, LAST_BONUS_KEY)
+    last_bonus && last_bonus != "" ? last_bonus.to_f : 1.0
+  end
+
+  def get_bonus(public_key)
+    return 1.0 unless is_purchased(public_key)
+    units = @game.get_player_time_units(public_key)
+    bonus = (units / 10000).floor
+    1.0 + (bonus * 0.01)
+  end
+
+  def buy_action(public_key)
+    puts "Purchasing Compound Interest"
+    if public_key
+      if !is_purchased(public_key) 
+        powerup = PowerupCompoundInterest.get_powerup_id
+        @game.inc_time_units(public_key, -BASE_PRICE)
+        @game.set_key_value(public_key, KEY, "true")
+        @game.add_powerup(public_key, powerup)
+        puts "Purchased Compound Interest"
+        apply_bonus(public_key)
+      else
+        puts "Already Purchased"
+      end
+    else
+      Nil
+    end
+  end
+
+  def apply_bonus(public_key)
+    current_rate = @game.get_player_time_units_ps(public_key)
+    old_bonus = get_last_bonus(public_key)
+    new_bonus = get_bonus(public_key)
+    if old_bonus != new_bonus
+      old_rate = current_rate / old_bonus
+      new_rate = old_rate * new_bonus
+      @game.set_player_time_units_ps(public_key, new_rate)
+      @game.set_key_value(public_key, LAST_BONUS_KEY, new_bonus.to_s)
+    end
+  end
+
+  def action(public_key, dt)
+    if public_key && is_purchased(public_key)
+        apply_bonus(public_key)
+    end
+  end
+end

--- a/src/powerups/unit_multiplier.cr
+++ b/src/powerups/unit_multiplier.cr
@@ -2,7 +2,7 @@ require "../powerup.cr"
 
 class PowerupUnitMultiplier < Powerup
   BASE_PRICE = 1000.0
-  MULTIPLIER = 1.05
+  MULTIPLIER = 1.3
   KEY = "unit_multiplier_stack"
 
   def self.get_powerup_id
@@ -14,7 +14,7 @@ class PowerupUnitMultiplier < Powerup
   end
 
   def get_description (public_key)
-    "Permanently increases units/s by 5%. Can be purchased multiple times with escalating costs."
+    "Permanently increases units/s by 30%. Can be purchased multiple times with escalating costs."
   end
 
   def is_stackable

--- a/src/worldwidewaitingroom.cr
+++ b/src/worldwidewaitingroom.cr
@@ -6,6 +6,7 @@ require "base64"
 require "./powerups/bootstrap.cr"
 require "./powerups/unit_multiplier.cr"
 require "./powerups/parasite.cr"
+require "./powerups/compound_interest"
 require "./templates"
 
 alias Secret = String
@@ -100,6 +101,7 @@ class Game
       PowerupBootStrap.get_powerup_id => PowerupBootStrap.new(self),
       PowerupUnitMultiplier.get_powerup_id => PowerupUnitMultiplier.new(self),
       PowerupParasite.get_powerup_id => PowerupParasite.new(self),
+      PowerupCompoundInterest.get_powerup_id => PowerupCompoundInterest.new(self),
     }
   end
 


### PR DESCRIPTION
Implemented the Compound Interest powerup.
Adds +1% to units/s for every 10,000 units the user currently holds.
Crossing any multiple of 10,000 units (by gaining or spending units) adjusts multiplier as necessary. 
This is a one-time purchase powerup.